### PR TITLE
Optimize finding the label

### DIFF
--- a/recaptcha.js
+++ b/recaptcha.js
@@ -1,4 +1,4 @@
-var label = document.querySelector('#recaptcha-anchor-label');
+var label = document.getElementById('recaptcha-anchor-label');
 if (label) {
 	label.innerText = chrome.i18n.getMessage('replacementText');
 }


### PR DESCRIPTION
Use `getElementById` instead of `querySelector` for improved performance... we don't need to start the CSS engine just to grab an element by its ID ;)